### PR TITLE
Fix R2 upload logic

### DIFF
--- a/src/lib/r2.ts
+++ b/src/lib/r2.ts
@@ -39,8 +39,10 @@ export async function uploadFileToR2(file: File, path: string): Promise<{ url: s
     ContentType: file.type,
   });
 
-  // Upload file using presigned URL
-  const upload = await fetch(key, {
+  // Upload file using a presigned URL
+  const presignedUrl = await getSignedUrl(r2Client, command, { expiresIn: 3600 });
+
+  const upload = await fetch(presignedUrl, {
     method: "PUT",
     body: file,
     headers: {


### PR DESCRIPTION
## Summary
- use a presigned URL when uploading to Cloudflare R2

## Testing
- `npx tsc -p tsconfig.json --noEmit` *(fails: Cannot find module '@aws-sdk/client-s3' and others)*