### PR TITLE
Add board action menu with edit & archive dialogs

### DIFF
--- a/src/components/board/edit-board-dialog.tsx
+++ b/src/components/board/edit-board-dialog.tsx
@@ -1,0 +1,60 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle
+} from '@/components/ui/dialog';
+import { Input } from '@/components/ui/input';
+import { useDebouncedCallback } from 'use-debounce';
+import { updateBoard } from '@/lib/actions';
+import { toast } from 'react-hot-toast';
+
+interface EditBoardDialogProps {
+  boardId: string;
+  boardName: string;
+  isOpen: boolean;
+  onClose: () => void;
+}
+
+export default function EditBoardDialog({
+  boardId,
+  boardName,
+  isOpen,
+  onClose
+}: EditBoardDialogProps) {
+  const [name, setName] = useState(boardName);
+
+  useEffect(() => {
+    if (isOpen) {
+      setName(boardName);
+    }
+  }, [boardName, isOpen]);
+
+  const debouncedSave = useDebouncedCallback(async (value: string) => {
+    if (!value) return;
+    const result = await updateBoard(boardId, { name: value });
+    if (!result.success) {
+      toast.error(result.error || 'Failed to update board');
+    }
+  }, 500);
+
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const value = e.target.value;
+    setName(value);
+    debouncedSave(value);
+  };
+
+  return (
+    <Dialog open={isOpen} onOpenChange={onClose}>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Edit Board Details</DialogTitle>
+        </DialogHeader>
+        <Input value={name} onChange={handleChange} />
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/components/board/top-bar.tsx
+++ b/src/components/board/top-bar.tsx
@@ -1,12 +1,12 @@
-"use client"
+'use client';
 
-import { useState } from "react"
-import { SidebarTrigger } from "@/components/ui/sidebar"
-import { Separator } from "@/components/ui/separator"
-import { ChevronDownIcon, PlusIcon } from "lucide-react"
-import { Button } from "@/components/ui/button"
-import { Board, User, Prisma } from "@prisma/client"
-import Link from "next/link"
+import { useState } from 'react';
+import { SidebarTrigger } from '@/components/ui/sidebar';
+import { Separator } from '@/components/ui/separator';
+import { ChevronDownIcon, PlusIcon, MoreHorizontal } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import { Board, User, Prisma } from '@prisma/client';
+import Link from 'next/link';
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -14,93 +14,153 @@ import {
   DropdownMenuItem,
   DropdownMenuLabel,
   DropdownMenuSeparator,
-  DropdownMenuTrigger,
-} from "@/components/ui/dropdown-menu"
-import CreateBoardDialog from "./create-board"
-import { UserAccessList } from "@/components/user-access-list"
+  DropdownMenuTrigger
+} from '@/components/ui/dropdown-menu';
+import CreateBoardDialog from './create-board';
+import EditBoardDialog from './edit-board-dialog';
+import { ConfirmDeleteAlert } from '@/components/confirm-delete-alert';
+import { deleteBoard } from '@/lib/actions';
+import { useRouter } from 'next/navigation';
+import { UserAccessList } from '@/components/user-access-list';
 
 type BoardWithRelations = Prisma.BoardGetPayload<{
-    include: {
-        createdBy: true;
-        collaborators: true;
-    }
-}>
+  include: {
+    createdBy: true;
+    collaborators: true;
+  };
+}>;
 
 type TopBarProps = {
-    activeBoard: BoardWithRelations;
-    boards: BoardWithRelations[];
-}
+  activeBoard: BoardWithRelations;
+  boards: BoardWithRelations[];
+};
 
-const BoardsTopBar = ({ activeBoard, boards}: TopBarProps) => {
-    console.log(activeBoard)
-    const [isOpen, setIsOpen] = useState(false);
-    const creator = activeBoard.createdBy
-    const collaborators = activeBoard.collaborators
-    const isPublic = !activeBoard.private
-    const privateBoards = boards.filter((board) => board.private).sort((a, b) => a.createdAt.getTime() - b.createdAt.getTime())
-    const publicBoards = boards.filter((board) => !board.private).sort((a, b) => a.createdAt.getTime() - b.createdAt.getTime())
+const BoardsTopBar = ({ activeBoard, boards }: TopBarProps) => {
+  const router = useRouter();
+  const [isOpen, setIsOpen] = useState(false);
+  const [isEditOpen, setIsEditOpen] = useState(false);
+  const [isDeleteOpen, setIsDeleteOpen] = useState(false);
+  const creator = activeBoard.createdBy;
+  const collaborators = activeBoard.collaborators;
+  const isPublic = !activeBoard.private;
+  const privateBoards = boards
+    .filter((board) => board.private)
+    .sort((a, b) => a.createdAt.getTime() - b.createdAt.getTime());
+  const publicBoards = boards
+    .filter((board) => !board.private)
+    .sort((a, b) => a.createdAt.getTime() - b.createdAt.getTime());
 
-    const onClose = () => {
-        setIsOpen(false);
+  const onClose = () => {
+    setIsOpen(false);
+  };
+
+  const handleDeleteBoard = async () => {
+    const result = await deleteBoard(activeBoard.id);
+    if (result.success) {
+      router.push('/');
     }
-    
-    
-    return (
-        <div className="sticky top-0 z-10 h-12 border-b p-4 bg-white dark:bg-gray-900 flex items-center justify-between gap-2 shrink-0 transition-[width,height] ease-linear group-has-[[data-collapsible=icon]]/sidebar-wrapper:h-12">
-            <div className="flex items-center gap-2">
-                <SidebarTrigger className="-ml-1" />
-                <Separator orientation="vertical" className="h-4" />
-                <DropdownMenu>
-                    <DropdownMenuTrigger asChild>
-                        <Button variant="ghost" className="gap-2 focus-visible:ring-0 px-2 max-h-8">
-                            {activeBoard.name} <ChevronDownIcon className="h-4 w-4" />
-                        </Button>
-                    </DropdownMenuTrigger>
-                    <DropdownMenuContent 
-                        align="start"
-                        side="bottom"
-                        sideOffset={4}
-                        className="w-56"
-                    >
-                        <DropdownMenuLabel className="text-xs text-muted-foreground">Private</DropdownMenuLabel>
-                        <DropdownMenuGroup>
-                            {
-                                privateBoards.length > 0 ? privateBoards.map((board) => (
-                                    <DropdownMenuItem key={board.id} asChild>
-                                        <Link href={`/board/${board.id}`}>
-                                        {board.name}
-                                        </Link>
-                                    </DropdownMenuItem>
-                                )) : (
-                                    <DropdownMenuItem className="text-xs text-muted-foreground">No private boards</DropdownMenuItem>
-                                )
-                            }
-                        </DropdownMenuGroup>
-                        <DropdownMenuSeparator />
-                        <DropdownMenuLabel className="text-xs text-muted-foreground">Public</DropdownMenuLabel>
-                        <DropdownMenuGroup>
-                            {
-                                publicBoards.map((board) => (
-                                    <DropdownMenuItem key={board.id} asChild>
-                                        <Link href={`/board/${board.id}`}>
-                                        {board.name}
-                                        </Link>
-                                    </DropdownMenuItem>
-                                ))
-                            }
-                        </DropdownMenuGroup>
-                        <DropdownMenuSeparator />
-                        <DropdownMenuItem className="text-muted-foreground" onClick={() => setIsOpen(true)}>
-                            <PlusIcon className="h-4 w-4 p-0.5 mr-2 ring-1 ring-current text-primary rounded-sm" />
-                            Create board
-                        </DropdownMenuItem>
-                    </DropdownMenuContent>
-                </DropdownMenu>
-            </div>
-            {creator && collaborators && <UserAccessList users={[creator, ...(collaborators || [])]} isPublic={isPublic} />}    
-            <CreateBoardDialog isOpen={isOpen} onClose={onClose} />
-        </div>
-    )
-}
+  };
+
+  return (
+    <div className="sticky top-0 z-10 h-12 border-b p-4 bg-white dark:bg-gray-900 flex items-center justify-between gap-2 shrink-0 transition-[width,height] ease-linear group-has-[[data-collapsible=icon]]/sidebar-wrapper:h-12">
+      <div className="flex items-center gap-2">
+        <SidebarTrigger className="-ml-1" />
+        <Separator orientation="vertical" className="h-4" />
+        <DropdownMenu>
+          <DropdownMenuTrigger asChild>
+            <Button
+              variant="ghost"
+              className="gap-2 focus-visible:ring-0 px-2 max-h-8"
+            >
+              {activeBoard.name} <ChevronDownIcon className="h-4 w-4" />
+            </Button>
+          </DropdownMenuTrigger>
+          <DropdownMenuContent
+            align="start"
+            side="bottom"
+            sideOffset={4}
+            className="w-56"
+          >
+            <DropdownMenuLabel className="text-xs text-muted-foreground">
+              Private
+            </DropdownMenuLabel>
+            <DropdownMenuGroup>
+              {privateBoards.length > 0 ? (
+                privateBoards.map((board) => (
+                  <DropdownMenuItem key={board.id} asChild>
+                    <Link href={`/board/${board.id}`}>{board.name}</Link>
+                  </DropdownMenuItem>
+                ))
+              ) : (
+                <DropdownMenuItem className="text-xs text-muted-foreground">
+                  No private boards
+                </DropdownMenuItem>
+              )}
+            </DropdownMenuGroup>
+            <DropdownMenuSeparator />
+            <DropdownMenuLabel className="text-xs text-muted-foreground">
+              Public
+            </DropdownMenuLabel>
+            <DropdownMenuGroup>
+              {publicBoards.map((board) => (
+                <DropdownMenuItem key={board.id} asChild>
+                  <Link href={`/board/${board.id}`}>{board.name}</Link>
+                </DropdownMenuItem>
+              ))}
+            </DropdownMenuGroup>
+            <DropdownMenuSeparator />
+            <DropdownMenuItem
+              className="text-muted-foreground"
+              onClick={() => setIsOpen(true)}
+            >
+              <PlusIcon className="h-4 w-4 p-0.5 mr-2 ring-1 ring-current text-primary rounded-sm" />
+              Create board
+            </DropdownMenuItem>
+          </DropdownMenuContent>
+        </DropdownMenu>
+      </div>
+      {creator && collaborators && (
+        <UserAccessList
+          users={[creator, ...(collaborators || [])]}
+          isPublic={isPublic}
+        />
+      )}
+      <DropdownMenu>
+        <DropdownMenuTrigger asChild>
+          <Button variant="ghost" size="icon" className="h-8 w-8">
+            <MoreHorizontal className="h-4 w-4" />
+          </Button>
+        </DropdownMenuTrigger>
+        <DropdownMenuContent align="end">
+          <DropdownMenuItem onSelect={() => setIsEditOpen(true)}>
+            Edit board details
+          </DropdownMenuItem>
+          <DropdownMenuItem disabled>Manage access</DropdownMenuItem>
+          <DropdownMenuSeparator />
+          <DropdownMenuItem
+            onSelect={() => setIsDeleteOpen(true)}
+            className="text-red-600"
+          >
+            Archive Board
+          </DropdownMenuItem>
+        </DropdownMenuContent>
+      </DropdownMenu>
+      <CreateBoardDialog isOpen={isOpen} onClose={onClose} />
+      <EditBoardDialog
+        isOpen={isEditOpen}
+        onClose={() => setIsEditOpen(false)}
+        boardId={activeBoard.id}
+        boardName={activeBoard.name}
+      />
+      <ConfirmDeleteAlert
+        isOpen={isDeleteOpen}
+        onCloseAction={() => setIsDeleteOpen(false)}
+        onConfirm={handleDeleteBoard}
+        resourceName="board"
+        confirmName={activeBoard.name}
+      />
+    </div>
+  );
+};
 
 export { BoardsTopBar };

--- a/src/components/confirm-delete-alert.tsx
+++ b/src/components/confirm-delete-alert.tsx
@@ -1,0 +1,85 @@
+'use client';
+
+import { useState, useEffect } from 'react';
+import { cn } from '@/lib/utils';
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle
+} from '@/components/ui/alert-dialog';
+import { Input } from '@/components/ui/input';
+
+interface ConfirmDeleteAlertProps {
+  isOpen: boolean;
+  onCloseAction: () => void;
+  onConfirm: () => void;
+  resourceName: string;
+  confirmName: string;
+}
+
+export function ConfirmDeleteAlert({
+  isOpen,
+  onCloseAction,
+  onConfirm,
+  resourceName,
+  confirmName
+}: ConfirmDeleteAlertProps) {
+  const [value, setValue] = useState('');
+
+  useEffect(() => {
+    if (isOpen) setValue('');
+  }, [isOpen]);
+
+  const handleConfirm = (e: React.MouseEvent<HTMLButtonElement>) => {
+    e.preventDefault();
+    if (value === confirmName) {
+      onConfirm();
+    }
+  };
+
+  const isValid = value === confirmName;
+
+  return (
+    <AlertDialog open={isOpen} onOpenChange={onCloseAction}>
+      <AlertDialogContent>
+        <AlertDialogHeader>
+          <AlertDialogTitle>
+            Are you sure you want to delete this {resourceName}?
+          </AlertDialogTitle>
+          <AlertDialogDescription>
+            This action cannot be undone. This will permanently delete the{' '}
+            {resourceName}.
+          </AlertDialogDescription>
+          <div className="pt-4 space-y-2">
+            <p className="text-sm">
+              Please type <span className="font-medium">{confirmName}</span> to
+              confirm.
+            </p>
+            <Input value={value} onChange={(e) => setValue(e.target.value)} />
+          </div>
+        </AlertDialogHeader>
+        <AlertDialogFooter>
+          <AlertDialogCancel data-no-dnd>Cancel</AlertDialogCancel>
+          <AlertDialogAction
+            disabled={!isValid}
+            className={cn(
+              'bg-red-600 hover:bg-red-700 focus:ring-red-500 text-white font-semibold',
+              {
+                'opacity-50 cursor-not-allowed': !isValid
+              }
+            )}
+            data-no-dnd
+            onClick={handleConfirm}
+          >
+            Delete
+          </AlertDialogAction>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
+  );
+}


### PR DESCRIPTION
## Summary
- add a new `ConfirmDeleteAlert` component with typed confirmation
- create `EditBoardDialog` for editing board name with debounce autosave
- extend `BoardsTopBar` with actions menu for editing and archiving boards

## Testing
- `npm test` *(fails: Missing script)*